### PR TITLE
Added missing requirements to run the ./example/weather_agent.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,6 @@ langchain_openai==0.0.5
 openai==1.10
 wikipedia
 duckduckgo-search
+openmeteo_requests==1.2.0
+requests_cache==1.2.0
+retry_requests==2.0.0


### PR DESCRIPTION
Updated requirements.txt: Added the missing libraries required to run the weather_agent.py script

- openmeteo_requests==1.2.0
- requests_cache==1.2.0
- retry_requests==2.0.0