### PR TITLE
Add vLLM backend for open weight model evaluation

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -25,11 +25,25 @@ bash ./run_dev.sh
 it is highly suggested running webshop in backend with `tmux`.
 
 2. Since AgentLite is using a different python version, you should create a new environment for AgentLite.
-3. Run AgentLite evaluation in this folder  with
+3. Run AgentLite evaluation in this folder with
+
 ```
 cd webshop
 python evaluate_webshop.py --llm gpt-4-0613 --agent_arch act
 ```
+
+To evaluate a model from the [Hugging Face Hub](https://huggingface.co/models) with a [vLLM](https://github.com/vllm-project/vllm) backend, first spin up the server with:
+
+```shell
+vllm serve Salesforce/xLAM-v0.1-r --tensor-parallel-size {NUM_GPUS}
+```
+
+Then, in a separate terminal run:
+
+```shell
+python evaluate_webshop.py --llm Salesforce/xLAM-v0.1-r --agent_arch act
+```
+
 
 ## Tool-query
 We follow [AgentBoard](https://github.com/hkust-nlp/AgentBoard) environment to setup the tool-query benchmark. And we designed the individual agent via AgentLite with all the corresponding function call as actions.

--- a/benchmark/webshop/evaluate_webshop.py
+++ b/benchmark/webshop/evaluate_webshop.py
@@ -88,7 +88,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     rewards = []
     all_task_ids = list(range(0, 251))
-    REWARD_LOG_FILE = f"{args.llm}_{args.agent_arch}_results_webshop.csv"
+    REWARD_LOG_FILE = f"{args.llm.replace('/', '_')}_{args.agent_arch}_results_webshop.csv"
     runned_ids = get_runned_ids(REWARD_LOG_FILE)
     if runned_ids is None:
         evaluate_ids = all_task_ids


### PR DESCRIPTION
This PR adds support for a vLLM backend so that Hugging Face models like `Salesforce/xLAM-v0.1-r` can be evaluated. I've shown how this works for WebShop and am happy to extend it to the other benchmarks if the API looks good to you.