### PR TITLE
hotpotqa: add local RAG retriever

### DIFF
--- a/benchmark/hotpotqa/SearchActions.py
+++ b/benchmark/hotpotqa/SearchActions.py
@@ -1,19 +1,77 @@
-import os
 import wikipedia
 
 from agentlite.actions.BaseAction import BaseAction
 
-class WikipediaSearch(BaseAction):
-    def __init__(self) -> None:
-        action_name = "Wikipedia_Search"
-        action_desc = "Using this API to search Wiki content."
-        params_doc = {"query": "the search string. be simple."}
 
+WIKIPEDIA_ACTION_NAME = "Wikipedia_Search"
+
+
+class WikipediaSearch(BaseAction):
+    def __init__(
+        self,
+        mode: str = "online",
+        rag_index_dir: str = None,
+        rag_top_k: int = None,
+        rag_strategy: str = None,
+        rag_embed_model: str = None,
+        rag_embedding_dim: int = None,
+        rag_cache_dir: str = None,
+        rag_device: str = None,
+        rag_text_lookup: str = None,
+    ) -> None:
+        action_name = WIKIPEDIA_ACTION_NAME
+        self.mode = mode.lower()
+        self.rag_top_k = int(rag_top_k) if rag_top_k is not None else None
+        self.retriever = None
+
+        if self.mode == "rag":
+            from local_wiki_retriever import LocalWikipediaRetriever
+
+            required_params = {
+                "rag_index_dir": rag_index_dir,
+                "rag_top_k": rag_top_k,
+                "rag_strategy": rag_strategy,
+                "rag_embed_model": rag_embed_model,
+                "rag_embedding_dim": rag_embedding_dim,
+                "rag_device": rag_device,
+                "rag_text_lookup": rag_text_lookup,
+            }
+            missing_params = [
+                name for name, value in required_params.items() if value is None
+            ]
+            if missing_params:
+                raise ValueError(
+                    "RAG mode requires explicit parameters: "
+                    + ", ".join(missing_params)
+                )
+
+            self.retriever = LocalWikipediaRetriever(
+                index_dir=rag_index_dir,
+                top_k=self.rag_top_k,
+                strategy=rag_strategy,
+                embed_model_name=rag_embed_model,
+                embedding_dim=int(rag_embedding_dim),
+                device=rag_device,
+                text_lookup=rag_text_lookup,
+                cache_dir=rag_cache_dir,
+            )
+            action_desc = "Search local Wikipedia corpus with RAG."
+        elif self.mode == "online":
+            action_desc = "Using this API to search Wiki content."
+        else:
+            raise ValueError(f"Unsupported WikipediaSearch mode: {self.mode}")
+
+        params_doc = {"query": "the search string. be simple."}
         super().__init__(
-            action_name=action_name, action_desc=action_desc, params_doc=params_doc,
+            action_name=action_name,
+            action_desc=action_desc,
+            params_doc=params_doc,
         )
 
     def __call__(self, query):
+        if self.mode == "rag":
+            return self.retriever.format_results(query, top_k=self.rag_top_k)
+
         search_results = wikipedia.search(query)
         if not search_results:
             return "No results found."

--- a/benchmark/hotpotqa/build_local_wiki_index.py
+++ b/benchmark/hotpotqa/build_local_wiki_index.py
@@ -1,0 +1,297 @@
+import argparse
+import bz2
+import json
+import re
+import shutil
+import time
+from pathlib import Path
+from typing import Iterator, List, Optional, Tuple
+
+
+DEFAULT_INPUT_DIR = "/home/xuzm/data/ICCAD2026/rag_cag_algorithm/TurboRAG/wikpedia_paragraphs"
+DEFAULT_PERSIST_DIR = "/home/xuzm/data/ICCAD2026/rag_cag_algorithm/TurboRAG/emb_wiki_bz2_nomic_agentlite"
+DEFAULT_EMBED_MODEL = "nomic-ai/nomic-embed-text-v1.5"
+DEFAULT_EMBEDDING_DIM = 256
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Build a simple local Wikipedia RAG index.")
+    parser.add_argument("--input_dir", type=str, default=DEFAULT_INPUT_DIR)
+    parser.add_argument("--persist_dir", type=str, default=DEFAULT_PERSIST_DIR)
+    parser.add_argument("--embed_model_name", type=str, default=DEFAULT_EMBED_MODEL)
+    parser.add_argument("--embedding_dim", type=int, default=DEFAULT_EMBEDDING_DIM)
+    parser.add_argument("--cache_dir", type=str, default=None)
+    parser.add_argument("--batch_size", type=int, default=256)
+    parser.add_argument("--encode_batch_size", type=int, default=None)
+    parser.add_argument("--max_files", type=int, default=None)
+    parser.add_argument("--max_records", type=int, default=None)
+    parser.add_argument("--log_every", type=int, default=5000)
+    parser.add_argument("--overwrite", action="store_true")
+    return parser.parse_args()
+
+
+def iter_bz_files(input_dir: Path) -> List[Path]:
+    return [
+        path
+        for path in sorted(input_dir.rglob("*"))
+        if path.is_file() and path.name.lower().endswith((".bz2", ".bz"))
+    ]
+
+
+def iter_jsonl_records(path: Path) -> Iterator[Tuple[int, Optional[dict]]]:
+    with bz2.open(path, mode="rt", encoding="utf-8", errors="replace") as fin:
+        for line_no, raw_line in enumerate(fin, start=1):
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                yield line_no, json.loads(line)
+            except json.JSONDecodeError:
+                yield line_no, None
+
+
+def normalize_text_segments(value) -> str:
+    if isinstance(value, list):
+        return "\n".join(str(part).strip() for part in value if str(part).strip()).strip()
+    if isinstance(value, str):
+        return value.strip()
+    return ""
+
+
+def sanitize_doc_key(raw_value: object, fallback_index: int) -> str:
+    text = str(raw_value or "").strip()
+    if not text:
+        return f"doc{fallback_index}"
+    text = re.sub(r"[^0-9A-Za-z-]+", "-", text).strip("-")
+    return text or f"doc{fallback_index}"
+
+
+def sanitize_relpath_tag(path: str) -> str:
+    return re.sub(r"[^0-9A-Za-z-]+", "-", path).strip("-") or "src"
+
+
+def build_node_text(title: str, body: str) -> str:
+    title = title.strip()
+    body = body.strip()
+    if title and body:
+        return f"Title: {title}\n\n{body}"
+    return title or body
+
+
+def build_record_payload(
+    record: dict,
+    source_file: Path,
+    source_relpath: str,
+    source_line: int,
+    fallback_index: int,
+):
+    title = str(record.get("title") or "").strip()
+    body = normalize_text_segments(record.get("text"))
+    node_text = build_node_text(title, body)
+    if not node_text:
+        return None, None, None
+
+    doc_key = sanitize_doc_key(record.get("id"), fallback_index)
+    source_tag = sanitize_relpath_tag(source_relpath)
+    node_id = f"chunk_{doc_key}_{source_tag}-{source_line}"
+    metadata = {
+        "node_id": node_id,
+        "record_id": str(record.get("id") or ""),
+        "title": title,
+        "url": str(record.get("url") or ""),
+        "source_file": source_file.name,
+        "source_relpath": source_relpath,
+        "source_line": source_line,
+    }
+    return node_id, node_text, metadata
+
+
+class SentenceTransformerEmbedder:
+    def __init__(
+        self,
+        model_name: str,
+        embedding_dim: int,
+        cache_dir: Optional[str] = None,
+        encode_batch_size: Optional[int] = None,
+    ) -> None:
+        import torch
+        import torch.nn.functional as F
+        from sentence_transformers import SentenceTransformer
+
+        self.torch = torch
+        self.F = F
+        self.model_name = model_name
+        self.embedding_dim = embedding_dim
+        self.encode_batch_size = encode_batch_size
+        self.model = SentenceTransformer(
+            model_name,
+            trust_remote_code=True,
+            cache_folder=cache_dir,
+        )
+        if hasattr(self.model, "max_seq_length"):
+            self.model.max_seq_length = 8192
+
+    def encode_documents(self, texts: List[str]):
+        normalized_name = self.model_name.lower()
+        encode_kwargs = {"convert_to_tensor": True, "show_progress_bar": False}
+        if self.encode_batch_size is not None:
+            encode_kwargs["batch_size"] = self.encode_batch_size
+        if "nomic-embed-text-v1.5" in normalized_name:
+            embeddings = self.model.encode(
+                [f"search_document: {text}" for text in texts],
+                **encode_kwargs,
+            )
+            embeddings = embeddings.to(self.torch.float32)
+            embeddings = self.F.layer_norm(embeddings, normalized_shape=(embeddings.shape[1],))
+            embeddings = embeddings[:, : self.embedding_dim]
+            embeddings = self.F.normalize(embeddings, p=2, dim=1)
+            return embeddings.to(self.torch.float16)
+        if "jina-embeddings-v3" in normalized_name:
+            embeddings = self.model.encode(
+                texts,
+                task="retrieval.passage",
+                prompt_name="retrieval.passage",
+                truncate_dim=self.embedding_dim,
+                **encode_kwargs,
+            )
+            embeddings = embeddings.to(self.torch.float32)
+            if embeddings.shape[1] > self.embedding_dim:
+                embeddings = embeddings[:, : self.embedding_dim]
+            embeddings = self.F.normalize(embeddings, p=2, dim=1)
+            return embeddings.to(self.torch.float16)
+        raise ValueError(f"Unsupported embedding model: {self.model_name}")
+
+
+def shard_dir(persist_dir: Path) -> Path:
+    return persist_dir / "shards"
+
+
+def save_shard(persist_dir: Path, shard_idx: int, node_ids, texts, metadata, embs) -> None:
+    import torch
+
+    path = shard_dir(persist_dir) / f"shard_{shard_idx:06d}.pt"
+    torch.save(
+        {"node_ids": node_ids, "texts": texts, "metadata": metadata, "embs": embs},
+        path,
+    )
+
+
+def finalize_outputs(persist_dir: Path, stats: dict) -> None:
+    import torch
+
+    all_node_ids = []
+    embedding_chunks = []
+    text_cache = {}
+    metadata_path = persist_dir / "codex_node_metadata.jsonl"
+
+    with open(metadata_path, "w", encoding="utf-8") as metadata_out:
+        for shard_path in sorted(shard_dir(persist_dir).glob("shard_*.pt")):
+            shard = torch.load(shard_path, map_location="cpu", weights_only=False)
+            node_ids = shard["node_ids"]
+            texts = shard["texts"]
+            metadata = shard["metadata"]
+            embs = shard["embs"]
+            all_node_ids.extend(node_ids)
+            embedding_chunks.append(embs.to(torch.float16))
+            for node_id, text in zip(node_ids, texts):
+                text_cache[node_id] = text
+            for meta in metadata:
+                metadata_out.write(json.dumps(meta, ensure_ascii=False) + "\n")
+
+    torch.save(
+        {"node_ids": all_node_ids, "embs": torch.cat(embedding_chunks, dim=0)},
+        persist_dir / "codex_vector_cache_float16.pt",
+    )
+    torch.save(text_cache, persist_dir / "codex_node_text_cache.pt")
+    with open(persist_dir / "codex_build_stats.json", "w", encoding="utf-8") as f:
+        json.dump(stats, f, ensure_ascii=False, indent=2)
+
+
+def main():
+    args = parse_args()
+    input_dir = Path(args.input_dir)
+    persist_dir = Path(args.persist_dir)
+    if not input_dir.is_dir():
+        raise ValueError(f"Input directory does not exist: {input_dir}")
+    if persist_dir.exists():
+        if not args.overwrite:
+            raise ValueError(f"Persist dir exists; pass --overwrite to replace it: {persist_dir}")
+        shutil.rmtree(persist_dir)
+    shard_dir(persist_dir).mkdir(parents=True, exist_ok=True)
+
+    embedder = SentenceTransformerEmbedder(
+        model_name=args.embed_model_name,
+        embedding_dim=args.embedding_dim,
+        cache_dir=args.cache_dir,
+        encode_batch_size=args.encode_batch_size or args.batch_size,
+    )
+    bz_files = iter_bz_files(input_dir)
+    if args.max_files is not None:
+        bz_files = bz_files[: args.max_files]
+
+    batch_node_ids, batch_texts, batch_metadata = [], [], []
+    inserted_records = skipped_records = malformed_records = total_chars = shard_idx = 0
+    start_time = time.time()
+
+    for file_idx, bz_path in enumerate(bz_files, start=1):
+        source_relpath = bz_path.relative_to(input_dir).as_posix()
+        print(f"[{file_idx}/{len(bz_files)}] Reading {source_relpath}")
+        for line_no, record in iter_jsonl_records(bz_path):
+            if args.max_records is not None and inserted_records >= args.max_records:
+                break
+            if record is None:
+                malformed_records += 1
+                continue
+            node_id, text, metadata = build_record_payload(
+                record=record,
+                source_file=bz_path,
+                source_relpath=source_relpath,
+                source_line=line_no,
+                fallback_index=inserted_records + skipped_records + malformed_records,
+            )
+            if node_id is None:
+                skipped_records += 1
+                continue
+            batch_node_ids.append(node_id)
+            batch_texts.append(text)
+            batch_metadata.append(metadata)
+            if len(batch_node_ids) >= args.batch_size:
+                embs = embedder.encode_documents(batch_texts)
+                save_shard(persist_dir, shard_idx, batch_node_ids, batch_texts, batch_metadata, embs)
+                shard_idx += 1
+                inserted_records += len(batch_node_ids)
+                total_chars += sum(len(item) for item in batch_texts)
+                batch_node_ids, batch_texts, batch_metadata = [], [], []
+                if args.log_every > 0 and inserted_records % args.log_every == 0:
+                    elapsed = max(time.time() - start_time, 1e-6)
+                    print(f"Inserted {inserted_records} records ({inserted_records / elapsed:.2f}/sec)")
+        if args.max_records is not None and inserted_records >= args.max_records:
+            break
+
+    if batch_node_ids:
+        embs = embedder.encode_documents(batch_texts)
+        save_shard(persist_dir, shard_idx, batch_node_ids, batch_texts, batch_metadata, embs)
+        inserted_records += len(batch_node_ids)
+        total_chars += sum(len(item) for item in batch_texts)
+        shard_idx += 1
+
+    stats = {
+        "inserted_records": inserted_records,
+        "skipped_records": skipped_records,
+        "malformed_records": malformed_records,
+        "total_chars": total_chars,
+        "avg_chars": total_chars / max(inserted_records, 1),
+        "embed_model_name": args.embed_model_name,
+        "embedding_dim": args.embedding_dim,
+        "num_shards": shard_idx,
+        "persist_mode": "agentlite_local_wiki_simple",
+        "finalized_at": time.time(),
+    }
+    finalize_outputs(persist_dir, stats)
+    print("Done.")
+    print(f"Index dir: {persist_dir}")
+    print(f"Inserted records: {inserted_records}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/hotpotqa/evaluate_hotpot_qa.py
+++ b/benchmark/hotpotqa/evaluate_hotpot_qa.py
@@ -10,7 +10,6 @@ import joblib
 import numpy as np
 import requests
 from tqdm import tqdm
-from SearchActions import WikipediaSearch
 from hotpotagents import WikiSearchAgent 
 
 
@@ -22,6 +21,12 @@ from agentlite.llm.agent_llms import BaseLLM, get_llm_backend
 from agentlite.llm.LLMConfig import LLMConfig
 from agentlite.logging.terminal_logger import AgentLogger
 
+
+DEFAULT_RAG_INDEX_DIR = "/home/xuzm/data/ICCAD2026/rag_cag_algorithm/TurboRAG/emb_wiki_bz2_nomic"
+DEFAULT_RAG_EMBED_MODEL = "nomic-ai/nomic-embed-text-v1.5"
+DEFAULT_RAG_EMBEDDING_DIM = 256
+DEFAULT_RAG_DEVICE = "cpu"
+DEFAULT_RAG_TEXT_LOOKUP = "cache"
 
 
 def download_file(url, filename):
@@ -90,7 +95,22 @@ def f1_score(prediction, ground_truth):
     return f1, precision, recall
 
 
-def run_hotpot_qa_agent(level="easy", llm_name="gpt-3.5-turbo-16k-0613", agent_arch="react", PROMPT_DEBUG_FLAG=False):
+def run_hotpot_qa_agent(
+    level="easy",
+    llm_name="gpt-3.5-turbo-16k-0613",
+    agent_arch="react",
+    PROMPT_DEBUG_FLAG=False,
+    search_mode="online",
+    rag_index_dir=DEFAULT_RAG_INDEX_DIR,
+    rag_top_k=5,
+    rag_strategy="cosine",
+    rag_embed_model=DEFAULT_RAG_EMBED_MODEL,
+    rag_embedding_dim=DEFAULT_RAG_EMBEDDING_DIM,
+    rag_cache_dir=None,
+    rag_device=DEFAULT_RAG_DEVICE,
+    rag_text_lookup=DEFAULT_RAG_TEXT_LOOKUP,
+    max_tasks=None,
+):
     """
     Test the WikiSearchAgent with a specified dataset level and LLM.
     """
@@ -107,8 +127,37 @@ def run_hotpot_qa_agent(level="easy", llm_name="gpt-3.5-turbo-16k-0613", agent_a
                 "api_key": "EMPTY"
             }
         )
-    llm = get_llm_backend(llm_config)
-    agent = WikiSearchAgent(llm=llm, agent_arch=agent_arch, PROMPT_DEBUG_FLAG=PROMPT_DEBUG_FLAG)
+    # running glm5.2 via siliconflow (OpenAI-compatible endpoint)
+    if llm_name in ["glm5.2", "glm-5.2"]:
+        llm_config = LLMConfig(
+            {
+                "llm_name": "zai-org/GLM-5.2",
+                "temperature": 0.0,
+                "base_url": "https://api.siliconflow.cn/v1",
+                "api_key": os.environ.get("SILICONFLOW_API_KEY", "EMPTY"),
+                "max_tokens": 1024,
+            }
+        )
+        # GLM-5.2 is a chat model, but not in OPENAI_CHAT_MODELS, so route
+        # explicitly to LangchainChatModel instead of the default completion path.
+        from agentlite.llm.agent_llms import LangchainChatModel
+        llm = LangchainChatModel(llm_config)
+    else:
+        llm = get_llm_backend(llm_config)
+    agent = WikiSearchAgent(
+        llm=llm,
+        agent_arch=agent_arch,
+        PROMPT_DEBUG_FLAG=PROMPT_DEBUG_FLAG,
+        search_mode=search_mode,
+        rag_index_dir=rag_index_dir,
+        rag_top_k=rag_top_k,
+        rag_strategy=rag_strategy,
+        rag_embed_model=rag_embed_model,
+        rag_embedding_dim=rag_embedding_dim,
+        rag_cache_dir=rag_cache_dir,
+        rag_device=rag_device,
+        rag_text_lookup=rag_text_lookup,
+    )
     # add several demo trajectories to the search agent for the HotPotQA benchmark
     hotpot_data = load_hotpot_qa_data(level)
     hotpot_data = hotpot_data.reset_index(drop=True)
@@ -116,6 +165,8 @@ def run_hotpot_qa_agent(level="easy", llm_name="gpt-3.5-turbo-16k-0613", agent_a
         (row["question"], row["answer"]) for _, row in hotpot_data.iterrows()
     ]
     f1_list, correct, results = [], 0, {}
+    if max_tasks is not None:
+        task_instructions = task_instructions[:max_tasks]
     for test_task, answer in tqdm(task_instructions, desc="Processing"):
         test_task_pack = TaskPackage(instruction=test_task)
         response = agent(test_task_pack)
@@ -137,7 +188,8 @@ def run_hotpot_qa_agent(level="easy", llm_name="gpt-3.5-turbo-16k-0613", agent_a
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="Test Search Agent on the HotPotQA Benchmark"
+        description="Test Search Agent on the HotPotQA Benchmark",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
         "--level",
@@ -164,9 +216,86 @@ if __name__ == "__main__":
         action='store_true',
         help="debug flag",
     )
+    parser.add_argument(
+        "--search_mode",
+        type=str,
+        choices=["online", "rag"],
+        default="rag",
+        help="Use online Wikipedia API or local RAG retrieval.",
+    )
+    parser.add_argument(
+        "--rag_index_dir",
+        type=str,
+        default=DEFAULT_RAG_INDEX_DIR,
+        help="Directory containing the local Wikipedia vector cache.",
+    )
+    parser.add_argument(
+        "--rag_top_k",
+        type=int,
+        default=5,
+        help="Number of local Wikipedia chunks returned to the LLM per search.",
+    )
+    parser.add_argument(
+        "--rag_strategy",
+        type=str,
+        default="cosine",
+        help="Local retrieval strategy. Currently supports: cosine.",
+    )
+    parser.add_argument(
+        "--rag_embed_model",
+        type=str,
+        default=DEFAULT_RAG_EMBED_MODEL,
+        help="Embedding model used for query encoding.",
+    )
+    parser.add_argument(
+        "--rag_embedding_dim",
+        type=int,
+        default=DEFAULT_RAG_EMBEDDING_DIM,
+        help="Embedding dimension used by the local index.",
+    )
+    parser.add_argument(
+        "--rag_cache_dir",
+        type=str,
+        default=None,
+        help="Optional local cache directory for embedding models.",
+    )
+    parser.add_argument(
+        "--rag_device",
+        type=str,
+        default=DEFAULT_RAG_DEVICE,
+        help="Torch device used for local RAG vectors and query embeddings.",
+    )
+    parser.add_argument(
+        "--rag_text_lookup",
+        type=str,
+        choices=["cache", "shards"],
+        default=DEFAULT_RAG_TEXT_LOOKUP,
+        help="Load retrieved text from the full text cache or by scanning shards.",
+    )
+    parser.add_argument(
+        "--max_tasks",
+        type=int,
+        default=None,
+        help="If set, only run the first N tasks (smoke test). None = full dataset.",
+    )
     args = parser.parse_args()
 
-    f1, acc = run_hotpot_qa_agent(level=args.level, llm_name=args.llm, agent_arch=args.agent_arch, PROMPT_DEBUG_FLAG=args.debug)
+    f1, acc = run_hotpot_qa_agent(
+        level=args.level,
+        llm_name=args.llm,
+        agent_arch=args.agent_arch,
+        PROMPT_DEBUG_FLAG=args.debug,
+        search_mode=args.search_mode,
+        rag_index_dir=args.rag_index_dir,
+        rag_top_k=args.rag_top_k,
+        rag_strategy=args.rag_strategy,
+        rag_embed_model=args.rag_embed_model,
+        rag_embedding_dim=args.rag_embedding_dim,
+        rag_cache_dir=args.rag_cache_dir,
+        rag_device=args.rag_device,
+        rag_text_lookup=args.rag_text_lookup,
+        max_tasks=args.max_tasks,
+    )
     print(
         f"{'+'*100}\nLLM model: {args.llm}, Dataset: {args.level}, Result: F1-Score = {f1:.4f}, Accuracy = {acc:.4f}"
     )

--- a/benchmark/hotpotqa/hotpotagents.py
+++ b/benchmark/hotpotqa/hotpotagents.py
@@ -1,4 +1,4 @@
-from SearchActions import WikipediaSearch
+from SearchActions import WIKIPEDIA_ACTION_NAME, WikipediaSearch
 
 from agentlite.actions import BaseAction, FinishAct, ThinkAct, PlanAct
 from agentlite.actions.InnerActions import INNER_ACT_KEY
@@ -8,12 +8,27 @@ from agentlite.llm.agent_llms import BaseLLM, get_llm_backend
 from agentlite.llm.LLMConfig import LLMConfig
 from agentlite.logging.terminal_logger import AgentLogger
 
+
 class WikiSearchAgent(BaseAgent):
     """
     Agent to search Wikipedia content and answer questions.
     """
 
-    def __init__(self, llm: BaseLLM, agent_arch: str = "react", PROMPT_DEBUG_FLAG=False):
+    def __init__(
+        self,
+        llm: BaseLLM,
+        agent_arch: str = "react",
+        PROMPT_DEBUG_FLAG=False,
+        search_mode: str = "online",
+        rag_index_dir: str = None,
+        rag_top_k: int = None,
+        rag_strategy: str = None,
+        rag_embed_model: str = None,
+        rag_embedding_dim: int = None,
+        rag_cache_dir: str = None,
+        rag_device: str = None,
+        rag_text_lookup: str = None,
+    ):
         name = "wiki_search_agent"
         role = "Answer questions by searching Wikipedia content."
         constraint = "Generation should be simple and clear."
@@ -26,11 +41,23 @@ class WikiSearchAgent(BaseAgent):
         else:
             reasoning_type = agent_arch
 
+        wiki_search_action = WikipediaSearch(
+            mode=search_mode,
+            rag_index_dir=rag_index_dir,
+            rag_top_k=rag_top_k,
+            rag_strategy=rag_strategy,
+            rag_embed_model=rag_embed_model,
+            rag_embedding_dim=rag_embedding_dim,
+            rag_cache_dir=rag_cache_dir,
+            rag_device=rag_device,
+            rag_text_lookup=rag_text_lookup,
+        )
+
         super().__init__(
             name=name,
             role=role,
             llm=llm,
-            actions=[WikipediaSearch()],
+            actions=[wiki_search_action],
             reasoning_type=reasoning_type,
             constraint=constraint,
             instruction=instruction, # common instruction will use default in agentlite.agent_prompts.prompt_utils.DEFAULT_PROMPT["agent_instruction"]
@@ -67,7 +94,7 @@ class WikiSearchAgent(BaseAgent):
 
         # 2. First search action and observation
         act_params1 = {"query": "Milhouse"}
-        act1_2 = AgentAct(name=WikipediaSearch().action_name, params=act_params1)
+        act1_2 = AgentAct(name=WIKIPEDIA_ACTION_NAME, params=act_params1)
         obs1_2 = "Milhouse Mussolini Van Houten is a recurring character in the Fox animated television series The Simpsons voiced by Pamela Hayden and created by Matt Groening. Groening chose the name Milhouse, also the middle name of President Richard Nixon, because it was the most unfortunate name [he] could think of for a kid"
 
         # 3. Second thought to refine search
@@ -101,7 +128,7 @@ class WikiSearchAgent(BaseAgent):
 
         # 2. First search action and observation for Pavel Urysohn
         act_params2_1 = {"query": "Pavel Urysohn"}
-        act2_2 = AgentAct(name=WikipediaSearch().action_name, params=act_params2_1)
+        act2_2 = AgentAct(name=WIKIPEDIA_ACTION_NAME, params=act_params2_1)
         obs2_2 = "Pavel Samuilovich Urysohn (February 3, 1898 â August 17, 1924) was a Soviet mathematician who is best known for his contributions in dimension theory."
 
         # 3. Second thought for searching Leonid Levin
@@ -111,7 +138,7 @@ class WikiSearchAgent(BaseAgent):
 
         # 4. Second search action and observation for Leonid Levin
         act_params2_2 = {"query": "Leonid Levin"}
-        act2_4 = AgentAct(name=WikipediaSearch().action_name, params=act_params2_2)
+        act2_4 = AgentAct(name=WIKIPEDIA_ACTION_NAME, params=act_params2_2)
         obs2_4 = "Leonid Anatolievich Levin is a Soviet-American mathematician and computer scientist."
 
         # 5. Final thought and finish action for task 2
@@ -147,7 +174,7 @@ class WikiSearchAgent(BaseAgent):
 
         # 1. First search action and observation
         act_params1 = {"query": "Milhouse"}
-        act1_1 = AgentAct(name=WikipediaSearch().action_name, params=act_params1)
+        act1_1 = AgentAct(name=WIKIPEDIA_ACTION_NAME, params=act_params1)
         obs1_1 = "Milhouse Mussolini Van Houten is a recurring character in the Fox animated television series The Simpsons voiced by Pamela Hayden and created by Matt Groening. Groening chose the name Milhouse, also the middle name of President Richard Nixon, because it was the most unfortunate name [he] could think of for a kid"
 
        # 2. Final thought and finish action
@@ -169,12 +196,12 @@ class WikiSearchAgent(BaseAgent):
 
         # 1. First search action and observation for Pavel Urysohn
         act_params2_1 = {"query": "Pavel Urysohn"}
-        act2_1 = AgentAct(name=WikipediaSearch().action_name, params=act_params2_1)
+        act2_1 = AgentAct(name=WIKIPEDIA_ACTION_NAME, params=act_params2_1)
         obs2_1 = "Pavel Samuilovich Urysohn (February 3, 1898 â August 17, 1924) was a Soviet mathematician who is best known for his contributions in dimension theory."
 
         # 2. Second search action and observation for Leonid Levin
         act_params2_2 = {"query": "Leonid Levin"}
-        act2_2 = AgentAct(name=WikipediaSearch().action_name, params=act_params2_2)
+        act2_2 = AgentAct(name=WIKIPEDIA_ACTION_NAME, params=act_params2_2)
         obs2_2 = "Leonid Anatolievich Levin is a Soviet-American mathematician and computer scientist."
 
         # 3. Final thought and finish action for task 2
@@ -209,7 +236,7 @@ class WikiSearchAgent(BaseAgent):
 
         # 2. First search action and observation
         act_params1 = {"query": "Milhouse"}
-        act1_2 = AgentAct(name=WikipediaSearch().action_name, params=act_params1)
+        act1_2 = AgentAct(name=WIKIPEDIA_ACTION_NAME, params=act_params1)
         obs1_2 = "Milhouse Mussolini Van Houten is a recurring character in the Fox animated television series The Simpsons voiced by Pamela Hayden and created by Matt Groening. Groening chose the name Milhouse, also the middle name of President Richard Nixon, because it was the most unfortunate name [he] could think of for a kid"
 
         # 3. Final thought and finish action
@@ -237,12 +264,12 @@ class WikiSearchAgent(BaseAgent):
 
         # 2. First search action and observation for Pavel Urysohn
         act_params2_1 = {"query": "Pavel Urysohn"}
-        act2_2 = AgentAct(name=WikipediaSearch().action_name, params=act_params2_1)
+        act2_2 = AgentAct(name=WIKIPEDIA_ACTION_NAME, params=act_params2_1)
         obs2_2 = "Pavel Samuilovich Urysohn (February 3, 1898 â August 17, 1924) was a Soviet mathematician who is best known for his contributions in dimension theory."
 
         # 3. Second search action and observation for Leonid Levin
         act_params2_2 = {"query": "Leonid Levin"}
-        act2_3 = AgentAct(name=WikipediaSearch().action_name, params=act_params2_2)
+        act2_3 = AgentAct(name=WIKIPEDIA_ACTION_NAME, params=act_params2_2)
         obs2_3 = "Leonid Anatolievich Levin is a Soviet-American mathematician and computer scientist."
 
         # 4. Final finish action for task 2
@@ -278,7 +305,7 @@ class WikiSearchAgent(BaseAgent):
 
         # 2. First search action and observation
         act_params1 = {"query": "Milhouse"}
-        act1_2 = AgentAct(name=WikipediaSearch().action_name, params=act_params1)
+        act1_2 = AgentAct(name=WIKIPEDIA_ACTION_NAME, params=act_params1)
         obs1_2 = "Milhouse Mussolini Van Houten is a recurring character in the Fox animated television series The Simpsons voiced by Pamela Hayden and created by Matt Groening. Groening chose the name Milhouse, also the middle name of President Richard Nixon, because it was the most unfortunate name [he] could think of for a kid"
 
         # 3. Second thought to refine search
@@ -312,7 +339,7 @@ class WikiSearchAgent(BaseAgent):
 
         # 2. First search action and observation for Pavel Urysohn
         act_params2_1 = {"query": "Pavel Urysohn"}
-        act2_2 = AgentAct(name=WikipediaSearch().action_name, params=act_params2_1)
+        act2_2 = AgentAct(name=WIKIPEDIA_ACTION_NAME, params=act_params2_1)
         obs2_2 = "Pavel Samuilovich Urysohn (February 3, 1898 â August 17, 1924) was a Soviet mathematician who is best known for his contributions in dimension theory."
 
         # 3. Second thought for searching Leonid Levin
@@ -322,7 +349,7 @@ class WikiSearchAgent(BaseAgent):
 
         # 4. Second search action and observation for Leonid Levin
         act_params2_2 = {"query": "Leonid Levin"}
-        act2_4 = AgentAct(name=WikipediaSearch().action_name, params=act_params2_2)
+        act2_4 = AgentAct(name=WIKIPEDIA_ACTION_NAME, params=act_params2_2)
         obs2_4 = "Leonid Anatolievich Levin is a Soviet-American mathematician and computer scientist."
 
         # 5. Final thought and finish action for task 2

--- a/benchmark/hotpotqa/local_wiki_retriever.py
+++ b/benchmark/hotpotqa/local_wiki_retriever.py
@@ -1,0 +1,246 @@
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence
+
+
+@dataclass
+class RetrievalResult:
+    node_id: str
+    text: str
+    score: float
+    metadata: Dict[str, str]
+
+
+#具体的检索方法，ivf/hnsw/enns/encoder
+class RetrievalStrategy:
+    name = "base"
+
+    def retrieve(self, query_embedding, document_embeddings, top_k: int):
+        raise NotImplementedError
+
+
+class CosineSimilarityStrategy(RetrievalStrategy):
+    name = "cosine"
+
+    def retrieve(self, query_embedding, document_embeddings, top_k: int):
+        import torch
+        import torch.nn.functional as F
+
+        if query_embedding.ndim == 1:
+            query_embedding = query_embedding.unsqueeze(0)
+        query_embedding = F.normalize(query_embedding.to(torch.float32), p=2, dim=1)
+        document_embeddings = F.normalize(document_embeddings.to(torch.float32), p=2, dim=1)
+        scores = torch.matmul(document_embeddings, query_embedding.squeeze(0))
+        top_k = min(top_k, scores.shape[0])
+        values, indices = torch.topk(scores, k=top_k)
+        return indices.cpu().tolist(), values.cpu().tolist()
+
+
+def build_strategy(name: str) -> RetrievalStrategy:
+    if not name:
+        raise ValueError("Retrieval strategy must be provided.")
+    normalized = name.lower()
+    if normalized == "cosine":
+        return CosineSimilarityStrategy()
+    raise ValueError(f"Unsupported retrieval strategy: {name}")
+
+
+class LocalWikipediaRetriever:
+    """Local Wikipedia retriever backed by precomputed embeddings.
+
+    The default on-disk format matches the TurboRAG builder outputs:
+    - codex_vector_cache_float16.pt: {"node_ids": [...], "embs": tensor}
+    - codex_node_text_cache.pt: {node_id: text}
+    - codex_node_metadata.jsonl: one metadata dict per node
+
+    Retrieval is strategy-based so cosine can later be swapped for FAISS/HNSW
+    or two-stage retrieval without touching AgentLite actions.
+    """
+
+    def __init__(
+        self,
+        index_dir: str,
+        top_k: int,
+        strategy: str,
+        embed_model_name: str,
+        embedding_dim: int,
+        device: str,
+        text_lookup: str,
+        cache_dir: Optional[str] = None,
+    ) -> None:
+        self.index_dir = Path(index_dir)
+        self.top_k = int(top_k)
+        self.strategy = build_strategy(strategy)
+        self.embed_model_name = embed_model_name
+        self.embedding_dim = int(embedding_dim)
+        self.cache_dir = cache_dir
+        self.device = device
+        self.text_lookup = text_lookup
+
+        self._torch = None
+        self._embedder = None
+        self._node_ids: List[str] = []
+        self._embeddings = None
+        self._metadata_by_id: Optional[Dict[str, Dict[str, str]]] = None
+        self._text_cache: Optional[Dict[str, str]] = None
+
+        self._load_vectors()
+
+    def _require_torch(self):
+        if self._torch is not None:
+            return self._torch
+        try:
+            import torch
+        except ImportError as exc:
+            raise ImportError(
+                "RAG mode requires torch. Install it in the agentlite environment "
+                "before using WikipediaSearch(mode='rag')."
+            ) from exc
+        self._torch = torch
+        return torch
+
+    def _load_vectors(self) -> None:
+        torch = self._require_torch()
+        vector_path = self.index_dir / "codex_vector_cache_float16.pt"
+        if not vector_path.is_file():
+            raise FileNotFoundError(f"Missing vector cache: {vector_path}")
+        vector_cache = torch.load(vector_path, map_location=self.device, weights_only=False)
+        self._node_ids = list(vector_cache["node_ids"])
+        self._embeddings = vector_cache["embs"].to(self.device)
+
+    def _load_embedder(self):
+        if self._embedder is not None:
+            return self._embedder
+        try:
+            import torch
+            import torch.nn.functional as F
+            from sentence_transformers import SentenceTransformer
+        except ImportError as exc:
+            raise ImportError(
+                "RAG mode requires sentence-transformers and torch to embed queries. "
+                "Install them in the agentlite environment before using local RAG."
+            ) from exc
+
+        model = SentenceTransformer(
+            self.embed_model_name,
+            trust_remote_code=True,
+            cache_folder=self.cache_dir,
+        )
+        if hasattr(model, "max_seq_length"):
+            model.max_seq_length = 8192
+        self._embedder = (model, torch, F)
+        return self._embedder
+
+    def _embed_query(self, query: str):
+        model, torch, F = self._load_embedder()
+        normalized_name = self.embed_model_name.lower()
+        if "nomic-embed-text-v1.5" in normalized_name:
+            texts = [f"search_query: {query}"]
+            embeddings = model.encode(texts, convert_to_tensor=True, show_progress_bar=False)
+            if embeddings.ndim == 1:
+                embeddings = embeddings.unsqueeze(0)
+            embeddings = embeddings.to(torch.float32)
+            embeddings = F.layer_norm(embeddings, normalized_shape=(embeddings.shape[1],))
+            embeddings = embeddings[:, : self.embedding_dim]
+            return F.normalize(embeddings, p=2, dim=1).to(self.device)
+        if "jina-embeddings-v3" in normalized_name:
+            embeddings = model.encode(
+                [query],
+                task="retrieval.query",
+                prompt_name="retrieval.query",
+                truncate_dim=self.embedding_dim,
+                convert_to_tensor=True,
+                show_progress_bar=False,
+            )
+            if embeddings.ndim == 1:
+                embeddings = embeddings.unsqueeze(0)
+            embeddings = embeddings.to(torch.float32)
+            if embeddings.shape[1] > self.embedding_dim:
+                embeddings = embeddings[:, : self.embedding_dim]
+            return F.normalize(embeddings, p=2, dim=1).to(self.device)
+        raise ValueError(f"Unsupported embedding model: {self.embed_model_name}")
+
+    def _load_metadata(self) -> Dict[str, Dict[str, str]]:
+        if self._metadata_by_id is not None:
+            return self._metadata_by_id
+        metadata_by_id: Dict[str, Dict[str, str]] = {}
+        path = self.index_dir / "codex_node_metadata.jsonl"
+        if path.is_file():
+            with open(path, "r", encoding="utf-8") as fin:
+                for line in fin:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    item = json.loads(line)
+                    node_id = str(item.get("node_id") or "")
+                    if node_id:
+                        metadata_by_id[node_id] = item
+        self._metadata_by_id = metadata_by_id
+        return metadata_by_id
+
+    def _load_text_cache(self) -> Dict[str, str]:
+        if self._text_cache is not None:
+            return self._text_cache
+        torch = self._require_torch()
+        path = self.index_dir / "codex_node_text_cache.pt"
+        if not path.is_file():
+            raise FileNotFoundError(f"Missing text cache: {path}")
+        self._text_cache = torch.load(path, map_location="cpu", weights_only=False)
+        return self._text_cache
+
+    def _load_texts_from_shards(self, node_ids: Sequence[str]) -> Dict[str, str]:
+        torch = self._require_torch()
+        pending = set(node_ids)
+        found: Dict[str, str] = {}
+        shards_dir = self.index_dir / "shards"
+        for shard_path in sorted(shards_dir.glob("shard_*.pt")):
+            if not pending:
+                break
+            shard = torch.load(shard_path, map_location="cpu", weights_only=False)
+            for node_id, text in zip(shard.get("node_ids", []), shard.get("texts", [])):
+                if node_id in pending:
+                    found[node_id] = text
+                    pending.remove(node_id)
+        return found
+
+    def _lookup_texts(self, node_ids: Sequence[str]) -> Dict[str, str]:
+        if self.text_lookup == "shards":
+            return self._load_texts_from_shards(node_ids)
+        cache = self._load_text_cache()
+        return {node_id: cache.get(node_id, "") for node_id in node_ids}
+
+    def search(self, query: str, top_k: Optional[int] = None) -> List[RetrievalResult]:
+        k = int(top_k or self.top_k)
+        if k <= 0:
+            return []
+        query_embedding = self._embed_query(query)
+        indices, scores = self.strategy.retrieve(query_embedding, self._embeddings, k)
+        metadata_by_id = self._load_metadata()
+        node_ids = [self._node_ids[idx] for idx in indices]
+        texts_by_id = self._lookup_texts(node_ids)
+        results = []
+        for node_id, score in zip(node_ids, scores):
+            results.append(
+                RetrievalResult(
+                    node_id=node_id,
+                    text=texts_by_id.get(node_id, ""),
+                    score=float(score),
+                    metadata=metadata_by_id.get(node_id, {}),
+                )
+            )
+        return results
+
+    def format_results(self, query: str, top_k: Optional[int] = None) -> str:
+        results = self.search(query=query, top_k=top_k)
+        if not results:
+            return "No results found."
+        blocks = []
+        for idx, item in enumerate(results, start=1):
+            title = item.metadata.get("title") or item.node_id
+            blocks.append(
+                f"[{idx}] title: {title}\n"
+                f"score: {item.score:.4f}\n"
+                f"content: {item.text}"
+            )
+        return "\n\n".join(blocks)


### PR DESCRIPTION
- New LocalWikipediaRetriever backed by precomputed nomic-embed-text-v1.5 embeddings (cosine over torch vector cache + text/metadata lookup).
- New build_local_wiki_index.py for building the local wiki index.
- evaluate_hotpot_qa: --search_mode {online,rag}, --max_tasks smoke flag, and a glm5.2 LLM branch that routes to LangchainChatModel against the siliconflow OpenAI-compatible endpoint (key via SILICONFLOW_API_KEY env).
- SearchActions / hotpotagents: wire the WikipediaSearch action and the ReAct examples to the local retriever.

Smoke (3 easy tasks, glm5.2 + rag on cuda) end-to-end: F1=0.5556, Acc=0.3333. Known issue: GLM-5.2 tends to emit Action: prefix so the ReAct parser rejected some steps; addressable in a follow-up.